### PR TITLE
Changes maintainer's name to it's github account

### DIFF
--- a/pkgs/applications/backup/cdpfgl/default.nix
+++ b/pkgs/applications/backup/cdpfgl/default.nix
@@ -16,7 +16,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/dupgit/sauvegarde;
     description = "Continuous data protection for GNU/Linux (cdpfgl).";
-    maintainers = "Olivier Delhomme";
+    maintainers = "with stdenv.lib.maintainers; [ dupgit ];
     license = licenses.gpl3;
     platforms = platforms.linux;
   };

--- a/pkgs/applications/backup/cdpfgl/default.nix
+++ b/pkgs/applications/backup/cdpfgl/default.nix
@@ -1,0 +1,23 @@
+{ stdenv, fetchurl, pkgconfig, intltool, glib, sqlite, jansson, 
+  libmicrohttpd, curl}:
+
+stdenv.mkDerivation rec {
+  name = "cdpfgl-${version}";
+  version = "0.0.11"; 
+
+  buildInputs = [ pkgconfig intltool glib sqlite jansson libmicrohttpd curl ]; 
+  outputs = [ "out" "dev" "man" ];
+
+  src = fetchurl {
+    url = "http://cdpfgl.delhomme.org/download/releases/${name}.tar.xz";
+    sha256 = "16ablsb2hnni0d28y73w1gk8j8gsmyd5rcjxx4n7zdv5ph8fz5bd";
+  };
+  
+  meta = with stdenv.lib; {
+    homepage = https://github.com/dupgit/sauvegarde;
+    description = "Continuous data protection for GNU/Linux (cdpfgl).";
+    maintainers = "Olivier Delhomme";
+    license = licenses.gpl3;
+    platforms = platforms.linux;
+  };
+}

--- a/pkgs/applications/backup/cdpfgl/default.nix
+++ b/pkgs/applications/backup/cdpfgl/default.nix
@@ -4,8 +4,9 @@
 stdenv.mkDerivation rec {
   name = "cdpfgl-${version}";
   version = "0.0.11"; 
-
-  buildInputs = [ pkgconfig intltool glib sqlite jansson libmicrohttpd curl ]; 
+  
+  nativeBuildInputs = [ pkgconfig intltool ];
+  buildInputs = [ glib sqlite jansson libmicrohttpd curl ]; 
   outputs = [ "out" "dev" "man" ];
 
   src = fetchurl {
@@ -16,7 +17,7 @@ stdenv.mkDerivation rec {
   meta = with stdenv.lib; {
     homepage = https://github.com/dupgit/sauvegarde;
     description = "Continuous data protection for GNU/Linux (cdpfgl).";
-    maintainers = "with stdenv.lib.maintainers; [ dupgit ];
+    maintainers = with maintainers; [ dupgit ];
     license = licenses.gpl3;
     platforms = platforms.linux;
   };

--- a/pkgs/top-level/all-packages.nix
+++ b/pkgs/top-level/all-packages.nix
@@ -96,6 +96,8 @@ with pkgs;
 
   buildMaven = callPackage ../build-support/build-maven.nix {};
 
+  cdpfgl = callPackage ../applications/backup/cdpfgl { };
+
   cmark = callPackage ../development/libraries/cmark { };
 
   dhallToNix = callPackage ../build-support/dhall-to-nix.nix {


### PR DESCRIPTION


###### Motivation for this change

To fit requirements of the project. lib/maintainers.nix has been modified accordingly in PR #30325

###### Things done

<!-- Please check what applies. Note that these are not hard requirements but merely serve as information for reviewers. -->

- [ ] Tested using sandboxing ([nix.useSandbox](http://nixos.org/nixos/manual/options.html#opt-nix.useSandbox) on NixOS, or option `build-use-sandbox` in [`nix.conf`](http://nixos.org/nix/manual/#sec-conf-file) on non-NixOS)
- Built on platform(s)
   - [ ] NixOS
   - [ ] macOS
   - [ ] other Linux distributions
- [ ] Tested via one or more NixOS test(s) if existing and applicable for the change (look inside [nixos/tests](https://github.com/NixOS/nixpkgs/blob/master/nixos/tests))
- [ ] Tested compilation of all pkgs that depend on this change using `nix-shell -p nox --run "nox-review wip"`
- [ ] Tested execution of all binary files (usually in `./result/bin/`)
- [ ] Fits [CONTRIBUTING.md](https://github.com/NixOS/nixpkgs/blob/master/.github/CONTRIBUTING.md).

---

